### PR TITLE
fix: no longer eval() PR-body table cells (RCE in CI runner)

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,14 +25,15 @@ def validate(repo_name: str, pr_number: int):
 
     # parse eta
     eta = prtime.parse_eta(pr, pr_id)
-    print("ETA: [%s]" % str(eta.d))
 
     exit = 0
 
     # validate
     if eta is None:
+        print("ETA: [None] (no valid ETA table found)")
         exit = 1
     else:
+        print("ETA: [%s]" % str(eta.d))
         valid, err_labels = eta.validate_hours()
         label_names += err_labels
         if not valid:

--- a/prtime.py
+++ b/prtime.py
@@ -231,6 +231,15 @@ class eta_table:
         return d
 
     def _validate_keys(self):
+        # A malformed / empty markdown table (e.g. a PR body that matches the
+        # trigger regex but has no real ETA rows) would otherwise raise
+        # IndexError below on self.rows[0]/[2]/[-1]/[-3] and crash the action.
+        # Treat "too few rows" as "not a valid ETA table".
+        if len(self.rows) < 3:
+            _logger.critical(
+                "Cannot parse, not enough ETA rows [%s]\n\t->[%s]",
+                self.pr_id, self.pr.html_url)
+            return False
         ver_1 = self.rows[0].name.lower() == ETA.key_phase
         ver_2 = ETA.key_eta in self.rows[-1].name.lower()
         ver_3 = True

--- a/prtime.py
+++ b/prtime.py
@@ -12,6 +12,7 @@ https://pygithub.readthedocs.io/en/latest/examples.html
 """
 import os
 import sys
+import ast
 import logging
 import argparse
 import re
@@ -82,13 +83,36 @@ def log_err(msg, pr, pr_id):
     _logger.info(tmpl, msg, pr_id, pr.html_url)
 
 
+_HOURS_EXPR_RE = re.compile(r"^\s*[\d\s+\-*/.()]+\s*$")
+
+
 def sum_hours(s, pr_id):
     """
         Try to sum the cell.
+
+        The cell is part of a markdown table inside a PR body, so the
+        author of any PR controls the string. Only accept arithmetic
+        over digits and the operators +-*/().  Anything else (function
+        calls, names, attribute access, dunder tricks) is rejected.
+        This used to be `float(eval(s))` which let any PR author run
+        arbitrary Python in the action container with the GitHub token
+        in scope.
     """
     try:
-        return float(eval(s))
-    except:
+        if s is None:
+            raise ValueError("empty")
+        text = str(s).strip()
+        if not text or not _HOURS_EXPR_RE.match(text):
+            raise ValueError("non-arithmetic input")
+        tree = ast.parse(text, mode="eval")
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Expression, ast.BinOp, ast.UnaryOp,
+                                  ast.Add, ast.Sub, ast.Mult, ast.Div,
+                                  ast.USub, ast.UAdd, ast.Constant, ast.Load)):
+                continue
+            raise ValueError("disallowed node: " + type(node).__name__)
+        return float(eval(compile(tree, "<sum_hours>", "eval"), {"__builtins__": {}}, {}))
+    except Exception:
         _logger.info("Cannot parse [%s] in [%s]", s, pr_id)
     return -1.
 

--- a/prtime.py
+++ b/prtime.py
@@ -83,7 +83,12 @@ def log_err(msg, pr, pr_id):
     _logger.info(tmpl, msg, pr_id, pr.html_url)
 
 
-_HOURS_EXPR_RE = re.compile(r"^\s*[\d\s+\-*/.()]+\s*$")
+_HOURS_EXPR_RE = re.compile(r"^ *[0-9 +\-*/.()]+ *$")
+# Cap input length and AST node count so a PR author can't DoS the action
+# runner by submitting `1+1+1+...` repeated tens of thousands of times.
+# Real ETA cells are short (a few additive terms); 256 is generous.
+_MAX_HOURS_EXPR_LEN = 256
+_MAX_HOURS_AST_NODES = 256
 
 
 def sum_hours(s, pr_id):
@@ -102,10 +107,18 @@ def sum_hours(s, pr_id):
         if s is None:
             raise ValueError("empty")
         text = str(s).strip()
-        if not text or not _HOURS_EXPR_RE.match(text):
+        if not text:
+            raise ValueError("empty")
+        if len(text) > _MAX_HOURS_EXPR_LEN:
+            raise ValueError("expression too long")
+        if not _HOURS_EXPR_RE.match(text):
             raise ValueError("non-arithmetic input")
         tree = ast.parse(text, mode="eval")
+        node_count = 0
         for node in ast.walk(tree):
+            node_count += 1
+            if node_count > _MAX_HOURS_AST_NODES:
+                raise ValueError("expression too complex")
             if isinstance(node, (ast.Expression, ast.BinOp, ast.UnaryOp,
                                   ast.Add, ast.Sub, ast.Mult, ast.Div,
                                   ast.USub, ast.UAdd, ast.Constant, ast.Load)):


### PR DESCRIPTION
## Summary

`prtime.py:90` (vendored from gh-prtime) did `float(eval(s))` over a string lifted out of a markdown table inside a PR body. **Because this code runs in the action container with `GITHUB_TOKEN` in scope, anyone editing any PR can execute arbitrary code as the runner and exfiltrate the token.**

Replaced with the same strict path used in the sibling `gh-prtime` PR:
1. Allow only `[0-9 +-*/.()]` characters.
2. `ast.parse` + walk; accept only `BinOp` / `UnaryOp` / `Constant`.
3. `compile` + `eval` with empty `__builtins__`.

## Origin
Found during a multi-repo security audit of the mazoea org.

## Test plan
- [ ] All existing valid hour cells (`1`, `1+2`, `1.5*2`, `(1+0.25)*4`) still parse to a float.
- [ ] Any non-arithmetic content returns -1 and logs the reject.
- [ ] Workflow runs against a benign PR body still produce the expected ETA report.