### PR TITLE
Bump actions/* to latest major versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: ./
       with:
         CONTEXT_GITHUB: ${{ toJson(github) }}


### PR DESCRIPTION
Update GitHub Actions to their current latest major releases:

- `actions/cache@v5`
- `actions/checkout@v6`
- `actions/download-artifact@v8`
- `actions/github-script@v9`
- `actions/setup-python@v6`
- `actions/stale@v10`
- `actions/upload-artifact@v7`

Only versions actually present in this repository's workflows are touched.

Note: newer majors of these actions ship with Node.js 24 runtime. Workflows that run inside legacy containers (Ubuntu 20 / older glibc) may need their container image bumped — watch CI.