### PR TITLE
chore: add gitleaks pre-commit hook + autoupdate revs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v6.0.0
     hooks:
     - id: check-json
     - id: mixed-line-ending
       args: ['--fix=lf']
       description: Forces to replace line ending by the UNIX 'lf' character.
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.6.0
+    rev: v2.0.4
     hooks:
     -   id: autopep8
         args:
@@ -15,9 +15,13 @@ repos:
         - --max-line-length=90
         - --ignore=E402
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v6.0.0
     hooks:
     -   id: check-added-large-files
         args:
         - --maxkb=10000
         - --enforce-all
+-   repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+    - id: gitleaks


### PR DESCRIPTION
## Summary
- Adds [gitleaks](https://github.com/gitleaks/gitleaks) v8.30.0 as a pre-commit hook so staged changes are scanned for hardcoded secrets before reaching git history.
- Bumps existing hook revs via `pre-commit autoupdate`.

## Test plan
- [x] `gitleaks detect` on full history — no leaks found
- [x] `pre-commit run` against this commit — all hooks pass
- [ ] CI green on this PR